### PR TITLE
ignore `ESRCH` on processes to be killed

### DIFF
--- a/ptrace/debugger/process.py
+++ b/ptrace/debugger/process.py
@@ -723,7 +723,11 @@ class PtraceProcess(object):
 
     def cont(self, signum=0):
         signum = self.filterSignal(signum)
-        ptrace_cont(self.pid, signum)
+        try:
+            ptrace_cont(self.pid, signum)
+        except PtraceError as error:
+            if error.errno != 3:
+                raise
         self.is_stopped = False
 
     def setoptions(self, options):


### PR DESCRIPTION
This patch has been rejected but I'm still using it and this pull request will serve a new discussion. From the stacktrace below you can see that it's `debugger.quit()` procedure we are talking about. Anything can happen during that procedure as we are killing a number of processes that depend on each other and do all sorts of stuff including quitting themselves before being killed by the debugger. 

In my opinion if the caller asks the debugger to quit, the debugger should be able to do that. Not catching an exception means that `debugger.quit()` doesn't even finish its job and bad things can happen like left over processes and stuff like that. If special care is expected on the caller side, `debugger.quit()` documentation should probably be updated.

----

Sometimes a debugged process is already gone when python-ptrace performs
steps to terminate it. In that case we need to gracefully ignore any
`ESRCH` errors.

This issue was discovered when running network-testing[1] and resulted
in the following traceback.

    Traceback (most recent call last):
      File "./test-client-server", line 5, in <module>
        main()
      File "/home/pavlix/oss/network-testing/network_testing/client_server.py", line 55, in main
        suite.run()
      File "/home/pavlix/oss/network-testing/network_testing/test_suite.py", line 431, in run
        testcase.run()
      File "/home/pavlix/oss/network-testing/network_testing/test_suite.py", line 391, in run
        scenario.run()
      File "/home/pavlix/oss/network-testing/network_testing/test_suite.py", line 172, in run
        debugger.quit()
      File "/home/pavlix/oss/network-testing/network_testing/debug.py", line 198, in quit
        super(SyscallDebugger, self).quit()
      File "/usr/lib64/python3.4/site-packages/ptrace/debugger/debugger.py", line 105, in quit
        process.terminate()
      File "/usr/lib64/python3.4/site-packages/ptrace/debugger/process.py", line 330, in terminate
        self.waitExit()
      File "/usr/lib64/python3.4/site-packages/ptrace/debugger/process.py", line 351, in waitExit
        self.cont(signum)
      File "/usr/lib64/python3.4/site-packages/ptrace/debugger/process.py", line 717, in cont
        ptrace_cont(self.pid, signum)
      File "/usr/lib64/python3.4/site-packages/ptrace/binding/func.py", line 212, in ptrace_cont
        ptrace(PTRACE_CONT, pid, 0, signum)
      File "/usr/lib64/python3.4/site-packages/ptrace/binding/func.py", line 148, in ptrace
        raise PtraceError(message, errno=errno, pid=pid)
    ptrace.error.PtraceError: ptrace(cmd=7, pid=12894, 0, 133) error #3: No such process

[1]: https://github.com/pavlix/network-testing